### PR TITLE
fix(laralog http kernal middleware): Fix type error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,10 @@
     ],
     "require": {
         "ext-json": "*",
-        "illuminate/container": "^5.6|^6.0|^7.0|^8.0|^9.0"
+        "illuminate/http": "^5.6|^6|^7|^8|^9",
+        "illuminate/support": "^5.6|^6|^7|^8|^9",
+        "illuminate/log": "^5.6|^6|^7|^8|^9",
+        "nesbot/carbon": "^1.0|^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/src/Http/Middleware/CaptureRequestLifecycle.php
+++ b/src/Http/Middleware/CaptureRequestLifecycle.php
@@ -6,11 +6,11 @@ namespace Shallowman\Laralog\Http\Middleware;
 
 use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Str;
 use function mb_substr;
 use Psr\Log\LoggerInterface;
 use Shallowman\Laralog\LaraLogger;
+use Symfony\Component\HttpFoundation\Response;
 
 class CaptureRequestLifecycle
 {


### PR DESCRIPTION
fix error [ argument 2 passed to Shallowman\Laralog\Http\Middleware\CaptureRequestLifecycle::captureAndComposeRequiredVariables() must be an instance of Illuminate\Http\Response].

Symfony\Component\HttpFoundation\Response
substitute for it.